### PR TITLE
fix: Build jq wheel from source

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ install:
 - sudo apt-get install -y graphviz
 - sudo apt-get install -y python-logilab-common
 - pip install -U setuptools
+- "python -m pip install jq --no-binary :all:"
 - pip install -U -e .[viz,develop,celery]
 script:
 - pyflakes yadage


### PR DESCRIPTION
To fix the CI, build the `jq` wheel from source. This is done as the [`v1.0.0` release](https://pypi.org/project/jq/1.0.0/) wheel causes errors with `libc.so.6`.