### PR TITLE
ci: Drop Python 2 for Python 3 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,9 @@ services:
 - docker
 language: python
 python:
-- '2.7'
-- '3.4'
-- '3.5'
 - '3.6'
+- '3.7'
+- '3.8'
 install:
 - sudo apt-get install -y imagemagick
 - sudo apt-get install -y graphviz


### PR DESCRIPTION
Drop testing of Python 2 for modern Python 3 runtimes: `3.6`, `3.7`, `3.8`. This is being done in part to prep for having Black be run again and for prepping for a move to GitHub Actions.