### PR TITLE
fix: Placate pyflakes unused named argument

### DIFF
--- a/yadage/utilcli.py
+++ b/yadage/utilcli.py
@@ -149,7 +149,7 @@ spec:
 """.format(
         pvc_name=pvc_name,
         sc_name=sc_name,
-        base_path=path_base,
+        path_base=path_base,
         size=size,
         path_base=path_base,
         hostname=hostname,


### PR DESCRIPTION
Fixes

```
$ pyflakes yadage/
yadage/utilcli.py:149:0 '...'.format(...) has unused named argument(s): base_path
```

Requires PR #95 to go in first.