### PR TITLE
fix: Correct name check to verify against yadage

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -49,7 +49,7 @@ jobs:
         password: ${{ secrets.test_pypi_password }}
         repository_url: https://test.pypi.org/legacy/
     - name: Publish distribution 📦 to PyPI
-      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && github.repository == 'scikit-hep/pyhf'
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && github.repository == 'yadage/yadage'
       uses: pypa/gh-action-pypi-publish@v1.1.0
       with:
         password: ${{ secrets.pypi_password }}

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -43,7 +43,7 @@ jobs:
       run: twine check dist/*
     - name: Publish distribution 📦 to Test PyPI
       # every PR will trigger a push event on master, so check the push event is actually coming from master
-      if: github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'scikit-hep/pyhf'
+      if: github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'yadage/yadage'
       uses: pypa/gh-action-pypi-publish@v1.1.0
       with:
         password: ${{ secrets.test_pypi_password }}


### PR DESCRIPTION
Amends PR #97 by fixing a sloppy mistake to update the name of the repository checked against for publishing to TestPyPI and PyPI.

```
* Correct GitHub repository name used for check to 'yadage/yadage'
```