### PR TITLE
chore: Update black to first stable release v22.1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
         "lint": [
             "pyflakes",
             "isort",
-            "black",
+            "black[jupyter]>=22.1.0",
         ],
         "develop": [
             "pre-commit",


### PR DESCRIPTION
```
* Set lower bound of black v22.1.0 for 'lint' extra
* Add jupyter extra for black to lint noteooks
```