### PR TITLE
fix: Use adage 'viz' extra to provide dependencies for 'viz' extra

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,13 +46,7 @@ setup(
     install_requires=deps,
     extras_require={
         "celery": ["celery", "redis"],
-        "viz": [
-            # manually adding extras of adage[extra] because of pip
-            # issue https://github.com/pypa/pip/issues/3189
-            "pydot2",
-            "pygraphviz",
-            "pydotplus",
-        ],
+        "viz": ["adage[viz]", "pydotplus"],
         "lint": [
             "pyflakes",
             "isort",

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     install_requires=deps,
     extras_require={
         "celery": ["celery", "redis"],
-        "viz": ["adage[viz]", "pydotplus"],
+        "viz": ["adage[viz]", "pydotplus>=2.0.0"],
         "lint": [
             "pyflakes",
             "isort",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ deps = [
     "adage",
     "packtivity",
     "yadage-schemas",
-    "click",
+    "click>=7.0.0,<8.0.0",  # FIXME: Cap of <8.0.0 is temporary
     "psutil",
     "requests[security]>=2.9",
     "pyyaml",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ deps = [
     "adage",
     "packtivity",
     "yadage-schemas",
-    "click>=7.0.0",
+    "click",
     "psutil",
     "requests[security]>=2.9",
     "pyyaml",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ deps = [
     "adage",
     "packtivity",
     "yadage-schemas",
-    "click>=7.0.0,<8.0.0",  # FIXME: Cap of <8.0.0 is temporary
+    "click>=7.0.0",
     "psutil",
     "requests[security]>=2.9",
     "pyyaml",

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     install_requires=deps,
     extras_require={
         "celery": ["celery", "redis"],
-        "viz": ["adage[viz]", "pydotplus>=2.0.0"],
+        "viz": ["adage[viz]>=0.10.3", "pydotplus>=2.0.0"],
         "lint": [
             "pyflakes",
             "isort",


### PR DESCRIPTION
`pip` Issue https://github.com/pypa/pip/issues/3189 is resolved now, so can use `adage[viz]` extra to provide the `pydot` and `pygraphviz`.

Partially addresses Issue #105 and Issue #106.

```
* Use adage[viz] to provide pydot>=1.2.3 and pygraphviz as pip Issue
3189 is resolved.
   - Set lower bound of adage[viz]>=0.10.3 to ensure proper lower
     bounds for pydot.
   - Results in pydot2 being dropped from viz extra.
```