### PR TITLE
fix: Unpack networkx dict_keyiterator object into list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 from setuptools import setup, find_packages
 
 deps = [
-    "adage",
+    "adage>=0.10.2",  # Ensure networkx>=2.4
     "packtivity",
     "yadage-schemas",
     "click",

--- a/yadage/manualutils.py
+++ b/yadage/manualutils.py
@@ -51,7 +51,7 @@ def preview_rule(wflow, name=None, identifier=None):
         if x.identifier not in existing_rules
     ]
     new_nodes = [
-        {"name": newflow.dag.getNode(n).name, "parents": newflow.dag.predecessors(n)}
+        {"name": newflow.dag.getNode(n).name, "parents": [*newflow.dag.predecessors(n)]}
         for n in newflow.dag.nodes()
         if n not in existing_nodes
     ]

--- a/yadage/strategies.py
+++ b/yadage/strategies.py
@@ -55,7 +55,7 @@ def target(name, opts=None):
         return False, False
 
     def upstream(dag, target_identifier):
-        predecessors = dag.predecessors(target_identifier)
+        predecessors = [*dag.predecessors(target_identifier)]
         return list(
             set(predecessors + [g for p in predecessors for g in upstream(dag, p)])
         )


### PR DESCRIPTION
Resolves #110

```
* Unpack networkx dict_keyiterator objects from iterator into list
   - For networkx v2.0 API:
     $ pydoc networkx.MultiDiGraph.predecessors | cat
     Help on function predecessors in networkx.MultiDiGraph:

     networkx.MultiDiGraph.predecessors = predecessors(self, n)
         Returns an iterator over predecessor nodes of n.

         A predecessor of n is a node m such that there exists a directed
         edge from m to n.

         Parameters
         ----------
         n : node
            A node in the graph

         Raises
         ------
         NetworkXError
            If n is not in the graph.

        ...
* Set lower bound on adage of v0.10.2 to ensure networkx>=2.4
```