### PR TITLE
ci: Run CI on PRs and pushes to master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,9 @@ name: CI/CD
 on:
   push:
   pull_request:
-  # Run daily at 0:01 UTC
+    branches:
+    - master
+  # Run daily at 1:23 UTC
   schedule:
   - cron:  '1 0 * * *'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,12 @@ on:
     - master
   # Run daily at 1:23 UTC
   schedule:
-  - cron:  '1 0 * * *'
+  - cron:  '23 1 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,11 @@ jobs:
   test:
 
     runs-on: ${{ matrix.os }}
+    # On push events run the CI only on master by default, but run on any branch if the commit message contains '[ci all]'
+    if: >-
+      github.event_name != 'push'
+      || (github.event_name == 'push' && github.ref == 'refs/heads/master')
+      || (github.event_name == 'push' && github.ref != 'refs/heads/master' && contains(github.event.head_commit.message, '[ci all]'))
     strategy:
       matrix:
         os: [ubuntu-latest]


### PR DESCRIPTION
```
* Run CI on push events to master by default, but on any branch on a push
event if the commit message contains '[ci all]'.
   - Results in a skip of push event tests on PRs by default.
* Run CI on pull_request events to master, on nightly CRON job schedule,
and on workflow dispatch.
* Add concurrency groups to avoid wasting resources.
```