### PR TITLE
build: Require Python 3.6+ for install and add PyPI classifiers metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,4 +68,20 @@ setup(
         ]
     },
     dependency_links=[],
+    classifiers=[
+        "Development Status :: 4 - Beta",
+        "Intended Audience :: Science/Research",
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3 :: Only",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: Implementation :: CPython",
+        "Topic :: Scientific/Engineering",
+        "Topic :: Scientific/Engineering :: Physics",
+        "Operating System :: OS Independent",
+    ],
 )

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
     author_email="lukas.heinrich@cern.ch",
     packages=find_packages(),
     include_package_data=True,
+    python_requires=">=3.6",
     install_requires=deps,
     extras_require={
         "celery": ["celery", "redis"],

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     name="yadage",
     version="0.20.1",
     description="yadage - YAML based adage",
-    url="",
+    url="https://github.com/yadage/yadage",
     author="Lukas Heinrich",
     author_email="lukas.heinrich@cern.ch",
     packages=find_packages(),


### PR DESCRIPTION
```
* Set python_requires=">=3.6"
* Add PyPI classifiers metadata
* Add project URL to setup info
```