### PR TITLE
test: Report code coverage in CI

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,13 @@
+[run]
+branch = True
+source = yadage 
+
+[report]
+exclude_lines =
+    if self.debug:
+    pragma: no cover
+    raise NotImplementedError
+    if __name__ == .__main__.:
+ignore_errors = True
+omit =
+    tests/*

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,6 @@
 [run]
 branch = True
-source = yadage 
+source = yadage
 
 [report]
 exclude_lines =

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,10 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     # On push events run the CI only on master by default, but run on any branch if the commit message contains '[ci all]'
-    if: >-
-      github.event_name != 'push'
-      || (github.event_name == 'push' && github.ref == 'refs/heads/master')
-      || (github.event_name == 'push' && github.ref != 'refs/heads/master' && contains(github.event.head_commit.message, '[ci all]'))
+    # if: >-
+    #   github.event_name != 'push'
+    #   || (github.event_name == 'push' && github.ref == 'refs/heads/master')
+    #   || (github.event_name == 'push' && github.ref != 'refs/heads/master' && contains(github.event.head_commit.message, '[ci all]'))
     strategy:
       matrix:
         os: [ubuntu-latest]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
 
     - name: Test with pytest
       run: |
-        pytest --cov=yadage
+        pytest -r sx
 
     - name: Report coverage with Codecov
       if: matrix.python-version == '3.10'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,10 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     # On push events run the CI only on master by default, but run on any branch if the commit message contains '[ci all]'
-    # if: >-
-    #   github.event_name != 'push'
-    #   || (github.event_name == 'push' && github.ref == 'refs/heads/master')
-    #   || (github.event_name == 'push' && github.ref != 'refs/heads/master' && contains(github.event.head_commit.message, '[ci all]'))
+    if: >-
+      github.event_name != 'push'
+      || (github.event_name == 'push' && github.ref == 'refs/heads/master')
+      || (github.event_name == 'push' && github.ref != 'refs/heads/master' && contains(github.event.head_commit.message, '[ci all]'))
     strategy:
       matrix:
         os: [ubuntu-latest]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,6 @@ jobs:
       if: matrix.python-version == '3.10'
       uses: codecov/codecov-action@v2
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml
         flags: unittests
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         pytest --cov=yadage
 
     - name: Report coverage with Codecov
-      if: github.event_name == 'push' && matrix.python-version == '3.10'
+      if: matrix.python-version == '3.10'
       uses: codecov/codecov-action@v2
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,7 @@
 *egg-info*
 htmlcov
 dist
-.coverage.*
+.coverage*
+!.coveragerc
+coverage*
 docs/_build

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,5 @@
+coverage:
+  status:
+    project:
+      default:
+        threshold: 0.2%

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["wheel", "setuptools>=30.3.0", "attrs>=17.1", "setuptools_scm"]
 build-backend = "setuptools.build_meta"
 
 [tool.black]
-target-version = ['py36', 'py37', 'py38']
+target-version = ['py36', 'py37', 'py38', 'py39', 'py310']
 include = '\.pyi?$'
 exclude = '''
 /(
@@ -25,5 +25,6 @@ addopts = [
     "--cov-report=term-missing",
     "--cov-report=xml",
     "--cov-report=html",
+    "--cov-report=annotate:coverage_annotate",
 ]
 testpaths = "tests"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,3 +13,17 @@ exclude = '''
   | build
 )/
 '''
+
+[tool.pytest.ini_options]
+minversion = "6.0"
+xfail_strict = true
+addopts = [
+    "--ignore=setup.py",
+    "--ignore=docs/",
+    "--cov=yadage",
+    "--cov-config=.coveragerc",
+    "--cov-report=term-missing",
+    "--cov-report=xml",
+    "--cov-report=html",
+]
+testpaths = "tests"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,0 @@
-[pytest]
-addopts = --ignore=setup.py --cov=yadage --cov-report=term-missing --cov-config=.coveragerc --cov-report xml

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-addopts = --ignore=setup.py --cov=yadage --cov-report=term-missing --cov-config=.coveragerc --cov-report html --cov-report html
+addopts = --ignore=setup.py --cov=yadage --cov-report=term-missing --cov-config=.coveragerc --cov-report xml

--- a/setup.py
+++ b/setup.py
@@ -55,9 +55,8 @@ setup(
         ],
         "develop": [
             "pre-commit",
-            "pytest>=3.2.0",
+            "pytest>=6.0.0",
             "pytest-cov>=2.5.1",
-            "python-coveralls",
         ],
     },
     entry_points={


### PR DESCRIPTION
```
* Add pytest tool options for html and annotated source code coverage reports
   - Remove pytest.ini as options now in pyproject.toml
* Fix reporting of coverage to Codecov in CI
* Configure Codecov with codecov.yml
* Add .coveragerc
* Remove unused python-coveralls from 'develop' extra
```