### PR TITLE
fix: Remove deprecated annotate cov-report option

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,5 @@ addopts = [
     "--cov-report=term-missing",
     "--cov-report=xml",
     "--cov-report=html",
-    "--cov-report=annotate:coverage_annotate",
 ]
 testpaths = "tests"


### PR DESCRIPTION
* Running with pytest option

```
--cov-report=annotate
```

gives a message of

```
The annotate command will be removed in a future version.
Get in touch if you still use it
```