### PR TITLE
ci: Update GitHub Action workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
@@ -105,7 +105,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Build Docker image
       if: "!(startsWith(github.ref, 'refs/tags/'))"
       uses: docker/build-push-action@v1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python
       uses: actions/setup-python@v4

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Build and Publish to Registry
       if: "!(startsWith(github.ref, 'refs/tags/'))"
       uses: docker/build-push-action@v1

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -70,7 +70,7 @@ jobs:
       if: >-
         (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'yadage/yadage')
         || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true' && github.repository == 'yadage/yadage')
-      uses: pypa/gh-action-pypi-publish@1.8.10
+      uses: pypa/gh-action-pypi-publish@v1.8.10
       with:
         password: ${{ secrets.test_pypi_password }}
         repository_url: https://test.pypi.org/legacy/
@@ -79,7 +79,7 @@ jobs:
     - name: Publish distribution 📦 to PyPI
       # publish to PyPI on releases
       if: github.event_name == 'release' && github.event.action == 'published' && github.repository == 'yadage/yadage'
-      uses: pypa/gh-action-pypi-publish@1.8.10
+      uses: pypa/gh-action-pypi-publish@v1.8.10
       with:
         password: ${{ secrets.pypi_password }}
         print-hash: true

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
@@ -70,16 +70,16 @@ jobs:
       if: >-
         (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && github.repository == 'yadage/yadage')
         || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true' && github.repository == 'yadage/yadage')
-      uses: pypa/gh-action-pypi-publish@v1.6.4
+      uses: pypa/gh-action-pypi-publish@1.8.10
       with:
         password: ${{ secrets.test_pypi_password }}
         repository_url: https://test.pypi.org/legacy/
-        print_hash: true
+        print-hash: true
 
     - name: Publish distribution 📦 to PyPI
       # publish to PyPI on releases
       if: github.event_name == 'release' && github.event.action == 'published' && github.repository == 'yadage/yadage'
-      uses: pypa/gh-action-pypi-publish@v1.6.4
+      uses: pypa/gh-action-pypi-publish@1.8.10
       with:
         password: ${{ secrets.pypi_password }}
-        print_hash: true
+        print-hash: true


### PR DESCRIPTION
Resolves #129 

* Update GitHub Action workflows:
   - actions/checkout: v3 -> v4
   - pypa/gh-action-pypi-publish: v1.6.4 -> v1.8.10