### PR TITLE
build: Require packtivity v0.16.2+

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ include_package_data = True
 python_requires = >=3.8
 install_requires =
     adage>=0.10.2  # Ensure networkx>=2.4
-    packtivity>=0.14.23
+    packtivity>=0.16.2  # Handle jqlang v1.6/v1.7
     yadage-schemas>=0.10.0
     click>=7.0
     psutil
@@ -49,7 +49,7 @@ install_requires =
     jsonpath_rw
     checksumdir
     glob2
-    jq
+    jq  # versions controlled through packtivity
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
* packtivity v0.16.2 properly handles the transition from jqlang v1.6 to v1.7.
   - c.f. https://github.com/yadage/packtivity/pull/99